### PR TITLE
travis: enable container-based infrastructure, test in 0.12 and io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+sudo: false
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "iojs"
 script:
   "node tests/tests.js"


### PR DESCRIPTION
* Enables Travis to run the tests in Node 0.12 and io.js
* Enables the container-based infrastructure