### PR TITLE
return an array with writeable indices

### DIFF
--- a/array-from.js
+++ b/array-from.js
@@ -68,7 +68,8 @@ if (!Array.from) {
 				defineProperty(A, k, {
 					'value': mappedValue,
 					'configurable': true,
-					'enumerable': true
+					'enumerable': true,
+					'writable': true
 				});
 				++k;
 			}

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -154,6 +154,12 @@ test('no setters are called for indexes', { skip: !Object.defineProperty }, func
 	t.end();
 });
 
+
+test('allows shift without throwing type error', function (t) { 
+	t.doesNotThrow(Array.prototype.shift.bind(Array.from([1,2,3])));
+	t.end();
+});
+
 // These tests take way too long to execute, sadly:
 /*
 test.skip('works with very large lengths', function (t) {


### PR DESCRIPTION
currently using this polyfill the following throws an error

```js
Array.from(new Uint8Array([1,2,3])).shift(); //Uncaught TypeError: Cannot assign to read only property '0' of [object Array]
```

If I'm reading it right the spec says to create an array with writable properties, 

22.1.2.1 Array.from:16f Let defineStatus be CreateDataPropertyOrThrow(A, Pk, mappedValue). (http://www.ecma-international.org/ecma-262/6.0/#sec-array.from)

7.3.6 CreateDataPropertyOrThrow:3 Let success be CreateDataProperty (http://www.ecma-international.org/ecma-262/6.0/#sec-createdatapropertyorthrow)

7.3.4 CreateDataProperty:3 Let newDesc be the PropertyDescriptor{[[Value]]: V, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true}. (http://www.ecma-international.org/ecma-262/6.0/#sec-createdataproperty)