### PR TITLE
separate polyfill from feature detect

### DIFF
--- a/array-from.js
+++ b/array-from.js
@@ -1,85 +1,83 @@
 /*! https://mths.be/array-from v0.2.0 by @mathias */
-if (!Array.from) {
-	(function() {
-		'use strict';
-		var defineProperty = (function() {
-			// IE 8 only supports `Object.defineProperty` on DOM elements.
-			try {
-				var object = {};
-				var $defineProperty = Object.defineProperty;
-				var result = $defineProperty(object, object, object) && $defineProperty;
-			} catch(error) {}
-			return result || function put(object, key, descriptor) {
-				object[key] = descriptor.value;
-			};
-		}());
-		var toStr = Object.prototype.toString;
-		var isCallable = function(fn) {
-			// In a perfect world, the `typeof` check would be sufficient. However,
-			// in Chrome 1–12, `typeof /x/ == 'object'`, and in IE 6–8
-			// `typeof alert == 'object'` and similar for other host objects.
-			return typeof fn == 'function' || toStr.call(fn) == '[object Function]';
+(function() {
+	'use strict';
+	var defineProperty = (function() {
+		// IE 8 only supports `Object.defineProperty` on DOM elements.
+		try {
+			var object = {};
+			var $defineProperty = Object.defineProperty;
+			var result = $defineProperty(object, object, object) && $defineProperty;
+		} catch(error) {}
+		return result || function put(object, key, descriptor) {
+			object[key] = descriptor.value;
 		};
-		var toInteger = function(value) {
-			var number = Number(value);
-			if (isNaN(number)) {
-				return 0;
-			}
-			if (number == 0 || !isFinite(number)) {
-				return number;
-			}
-			return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
-		};
-		var maxSafeInteger = Math.pow(2, 53) - 1;
-		var toLength = function(value) {
-			var len = toInteger(value);
-			return Math.min(Math.max(len, 0), maxSafeInteger);
-		};
-		var from = function from(arrayLike) {
-			var C = this;
-			if (arrayLike == null) {
-				throw new TypeError('`Array.from` requires an array-like object, not `null` or `undefined`');
-			}
-			var items = Object(arrayLike);
-			var mapping = arguments.length > 1;
-
-			var mapFn, T;
-			if (arguments.length > 1) {
-				mapFn = arguments[1];
-				if (!isCallable(mapFn)) {
-					throw new TypeError('When provided, the second argument to `Array.from` must be a function');
-				}
-				if (arguments.length > 2) {
-					T = arguments[2];
-				}
-			}
-
-			var len = toLength(items.length);
-			var A = isCallable(C) ? Object(new C(len)) : new Array(len);
-			var k = 0;
-			var kValue, mappedValue;
-			while (k < len) {
-				kValue = items[k];
-				if (mapFn) {
-					mappedValue = typeof T == 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
-				} else {
-					mappedValue = kValue;
-				}
-				defineProperty(A, k, {
-					'value': mappedValue,
-					'configurable': true,
-					'enumerable': true,
-					'writable': true
-				});
-				++k;
-			}
-			A.length = len;
-			return A;
-		};
-		defineProperty(Array, 'from', {
-			'value': from,
-			'configurable': true,
-			'writable': true
-		});
 	}());
-}
+	var toStr = Object.prototype.toString;
+	var isCallable = function(fn) {
+		// In a perfect world, the `typeof` check would be sufficient. However,
+		// in Chrome 1–12, `typeof /x/ == 'object'`, and in IE 6–8
+		// `typeof alert == 'object'` and similar for other host objects.
+		return typeof fn == 'function' || toStr.call(fn) == '[object Function]';
+	};
+	var toInteger = function(value) {
+		var number = Number(value);
+		if (isNaN(number)) {
+			return 0;
+		}
+		if (number == 0 || !isFinite(number)) {
+			return number;
+		}
+		return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+	};
+	var maxSafeInteger = Math.pow(2, 53) - 1;
+	var toLength = function(value) {
+		var len = toInteger(value);
+		return Math.min(Math.max(len, 0), maxSafeInteger);
+	};
+	var from = function from(arrayLike) {
+		var C = this;
+		if (arrayLike == null) {
+			throw new TypeError('`Array.from` requires an array-like object, not `null` or `undefined`');
+		}
+		var items = Object(arrayLike);
+		var mapping = arguments.length > 1;
+
+		var mapFn, T;
+		if (arguments.length > 1) {
+			mapFn = arguments[1];
+			if (!isCallable(mapFn)) {
+				throw new TypeError('When provided, the second argument to `Array.from` must be a function');
+			}
+			if (arguments.length > 2) {
+				T = arguments[2];
+			}
+		}
+
+		var len = toLength(items.length);
+		var A = isCallable(C) ? Object(new C(len)) : new Array(len);
+		var k = 0;
+		var kValue, mappedValue;
+		while (k < len) {
+			kValue = items[k];
+			if (mapFn) {
+				mappedValue = typeof T == 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
+			} else {
+				mappedValue = kValue;
+			}
+			defineProperty(A, k, {
+				'value': mappedValue,
+				'configurable': true,
+				'enumerable': true,
+				'writable': true
+			});
+			++k;
+		}
+		A.length = len;
+		return A;
+	};
+	defineProperty(Array, 'from', {
+		'value': from,
+		'configurable': true,
+		'writable': true
+	});
+}());

--- a/detect.js
+++ b/detect.js
@@ -1,0 +1,3 @@
+if (!Array.from) {
+  require('./array-from');
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.2.0",
 	"description": "A robust & optimized `Array.from` polyfill, based on the ECMAScript 6 specification.",
 	"homepage": "https://mths.be/array-from",
-	"main": "array-from.js",
+	"main": "detect.js",
 	"keywords": [
 		"array",
 		"es6",
@@ -22,7 +22,8 @@
 	"bugs": "https://github.com/mathiasbynens/Array.from/issues",
 	"files": [
 		"LICENSE-MIT.txt",
-		"array-from.js"
+		"array-from.js",
+		"detect.js"
 	],
 	"directories": {
 		"test": "tests"


### PR DESCRIPTION
With the two together, it is impossible to test whether the module
works in engines which partially support Array.from such as node v5.

With the two separated, we can test in all engines and we can more
easily use this polyfill inside of the Financial Times's polyfill-service.

As this pull request contains a lot of whitespace changes, here is a link which should make the actual changes easier to view -- https://github.com/mathiasbynens/Array.from/pull/21/files?w=1