### PR TITLE
fix: Update to latest ES Shims API

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,12 @@ var implementation = require('./implementation');
 var getPolyfill = require('./polyfill');
 var shim = require('./shim');
 
+var polyfill = getPolyfill();
+
 // eslint-disable-next-line no-unused-vars
-var boundFromShim = function from(array) {
+var boundFromShim = function from(items) {
 	// eslint-disable-next-line no-invalid-this
-	return implementation.apply(this || Array, arguments);
+	return polyfill.apply(this || Array, arguments);
 };
 
 define(boundFromShim, {


### PR DESCRIPTION
This adds the `auto.js` file and updates `index.js` to use the result of `getPolyfill()`, rather than always using the implementation, [as required by the latest version of the **es‑shim API**](https://github.com/es-shims/es-shim-api/blob/c17e78e8d245bb925f2b1bf8da505eef0783bcef/README.md#api-contract).